### PR TITLE
Bugfix: incorrect balance is displayed on add liquidity pool form

### DIFF
--- a/src/components/Tailwind/InputFields/CurrencyInput.tsx
+++ b/src/components/Tailwind/InputFields/CurrencyInput.tsx
@@ -37,7 +37,7 @@ const TokenInput = ({
   const currencyBalance = useCurrencyBalance(account ?? undefined, currency)
 
   const onMax = () => {
-    balance = balance ? balance : currencyBalance?.toSignificant(6)
+    balance = balance ? balance : currencyBalance?.toExact()
     if (balance && Number(balance) > 0) {
       didChangeValue(balance)
     }
@@ -72,8 +72,8 @@ const TokenInput = ({
               <div className="text-xs text-secondary-alternate uppercase font-semibold tracking-widest">
                 Balance:{' '}
                 {balance
-                  ? formatNumber(Number(balance), NumberFormat.long) || '-'
-                  : currencyBalance?.toSignificant(6) || '-'}
+                  ? formatNumber(Number(balance), NumberFormat.long)
+                  : currencyBalance?.toFixed(2, { groupSeparator: ',' }) || '-'}
               </div>
             )}
             <NumericalInput


### PR DESCRIPTION
## Description of Changes

- Fixed the incorrect balance by using `toFixed()` instead of `toSignificant()` as formatter
- Also fix the max button not using the full token balance

[Link to Jira Ticket](https://halodao.atlassian.net/browse/HDEV-59)


### Developer Checklist:

* [x] I have followed the guidelines in our Contributing document
* [x] This PR has a corresponding JIRA ticket
* [x] My branch conforms with our naming convention i.e. `feature/HDEV-XXX-description`
* [x] All files have appropriate file headers and documentation
* [ ] I have written new tests for your core changes, as applicable
* [ ] I have successfully ran tests locally

### Reviewers Checklist:
* [ ] Code is readable and understandable; any unclear parts have explanations 
* [ ] UI/UX changes match the corresponding figma/other design resources, if applicable
* [ ] I have successfully ran tests locally
