### PR TITLE
Bugfix: better if condition wether to use zapFromBase or zapFromQuote

### DIFF
--- a/src/pages/Tailwind/Pool/liquidity/SingleSidedLiquidity.tsx
+++ b/src/pages/Tailwind/Pool/liquidity/SingleSidedLiquidity.tsx
@@ -76,7 +76,7 @@ const SingleSidedLiquidity = ({
 
     let calcBaseAmount = 0
     let calcQuoteAmount = 0
-    const zapFromBase = selectedToken === pool.token0
+    const zapFromBase = selectedToken.address.toLowerCase() === pool.token0.address.toLowerCase()
     if (zapFromBase) {
       try {
         const swapAmount = await calcSwapAmountForZapFromBase(val)


### PR DESCRIPTION
This a bug fix for the bug me and Paul has discovered while testing the single sided deposit today.

Quoting this from https://docs.google.com/spreadsheets/d/1O8nDKDAOQlGqGOZESDt1tuTRHP2JeswUFVO9tI-8tCw/edit#gid=817367294:

> Possible UI issue, exact scenario:
> 1. Perform hard refresh on Pool page
> 2. Select Ethereum as network
> 3. Select UST/USDC
> 4. Select single-sided
> 5. Check if UST is selected by default
> 6. Enter 1 = execution reverted: Curve/lower-halt
> 7. Enter 10 = execution reverted: Curve/swap-convergence-failed
> 8. Enter 100 = execution reverted: Curve/lower-halt
> 9. Enter 1000 = execution reverted: Curve/lower-halt
> 10. Select USDC
> 11. Enter 1= execution reverted: Curve/lower-halt
> 12. Enter 10 = execution reverted: Curve/swap-convergence-failed
> 13. Enter 100 = execution reverted: Curve/lower-halt
> 14. Enter 1000 = execution reverted: Curve/lower-halt
> 15. Select UST
> 16. Enter 1 = no error
> 17. Enter 10 = no error
> 18. Enter 100 = no error
> 19 Enter 1000 = execution reverted: Curve/upper-halt"