### PR TITLE
refactor: error messages implementation

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -136,7 +136,7 @@
   "apr-breakdown": "APR Breakdown:",
   "insufficient-reward-balance": "Please ask protocol to top up rewards.",
   "harvest-failed": "Harvest failed. Please try again.",
-  "errorMessageCurveDefault": "Something went wrong. Please try to input a different amount.",
+  "errorMessageCurveDefault": "Something went wrong. You may try to enter a different amount.",
   "errorMessageCurveReentered": "Critical error. Please contact the team.",
   "errorMessageCurveAllowance": "Allowance error. Please contact the team.",
   "errorMessageCurveFrozen": "Contract is currently frozen. Only proportional withdraw allowed.",
@@ -151,6 +151,7 @@
   "errorMessageSubtractionOverflow": "Calculation Error. Please try a different amount.",
   "errorMessageMetamaskRejection": "User rejected transaction.",
   "errorMessageSafeMathDivisionByZero": "Calculation Error. Please try a different amount.",
+  "errorMessageGeneric": "Something went wrong. Please try again.",
   "baseApr": "Base APR",
   "slippageTolerance": "Your transaction will revert if the price changes unfavorably by more than this percentage."
 }

--- a/src/components/Tailwind/ErrorContent/InlineErrorContent.tsx
+++ b/src/components/Tailwind/ErrorContent/InlineErrorContent.tsx
@@ -1,32 +1,33 @@
-import React, { useEffect, useState } from 'react'
-import useErrorMessage, { HaloError } from 'halo-hooks/useErrorMessage'
+import React, { useEffect } from 'react'
+import useErrorMessage from 'halo-hooks/useErrorMessage'
 
 interface InlineErrorContentProps {
-  errorObject: HaloError
+  error: Error
   displayDetails?: boolean
 }
 
-const InlineErrorContent = ({ errorObject, displayDetails }: InlineErrorContentProps) => {
+const InlineErrorContent = ({ error, displayDetails }: InlineErrorContentProps) => {
   const { friendlyErrorMessage, getFriendlyErrorMessage } = useErrorMessage()
 
   useEffect(() => {
-    getFriendlyErrorMessage(errorObject)
-  }, [errorObject]) // eslint-disable-line
+    getFriendlyErrorMessage(error)
+  }, [error, displayDetails]) // eslint-disable-line
 
   return (
     <div className="bg-error-light border-solid border border-red-600 rounded">
-      <div className="text-center text-sm mb-2">
-        {displayDetails && (
+      <div className="text-center text-sm py-2">
+        {displayDetails ? (
           <>
-            <div className="font-semibold ">ERROR #: {errorObject.code}</div>
+            {(error as any).code && <div className="font-semibold ">ERROR #: {(error as any).code}</div>}
             <div className="text-center text-sm mb-2">
               {friendlyErrorMessage}. Please show this error message: &quot;
-              <span className="text-primary-red">{errorObject.message} </span>&quot; to the team on Discord or email us
-              at dev@halodao.com.
+              <span className="text-primary-red">{error.message} </span>&quot; to the team on Discord or email us at
+              dev@halodao.com.
             </div>
           </>
+        ) : (
+          <span className="text-primary-red"> {friendlyErrorMessage} </span>
         )}
-        {!displayDetails && <span className="text-primary-red"> {friendlyErrorMessage} </span>}
       </div>
     </div>
   )

--- a/src/components/Tailwind/ErrorContent/ModalErrorContent.tsx
+++ b/src/components/Tailwind/ErrorContent/ModalErrorContent.tsx
@@ -1,20 +1,20 @@
 import React, { useEffect, useState } from 'react'
 import OrangeWarningIcon from 'assets/svg/orange-warning-icon.svg'
 import Copy from '../../AccountDetails/Copy'
-import useErrorMessage, { HaloError } from 'halo-hooks/useErrorMessage'
+import useErrorMessage from 'halo-hooks/useErrorMessage'
 
 interface ModalErrorContentProps {
-  errorObject: HaloError
+  error: Error
   onDismiss: () => void
 }
 
-const ModalErrorContent = ({ errorObject, onDismiss }: ModalErrorContentProps) => {
+const ModalErrorContent = ({ error, onDismiss }: ModalErrorContentProps) => {
   const [showMore, setShowMore] = useState(false)
   const { friendlyErrorMessage, getFriendlyErrorMessage } = useErrorMessage()
 
   useEffect(() => {
-    getFriendlyErrorMessage(errorObject)
-  }, [errorObject, getFriendlyErrorMessage])
+    getFriendlyErrorMessage(error)
+  }, [error]) // eslint-disable-line
 
   return (
     <div className="p-4">
@@ -37,11 +37,11 @@ const ModalErrorContent = ({ errorObject, onDismiss }: ModalErrorContentProps) =
         {showMore && (
           <div className="flex flex-col justify-center items-center text-center rounded w-11/12 p-4 mt-4 bg-primary-midGray">
             <div className="flex justify-center items-center text-center">
-              <p className="italic mb-2.5 text-sm">{errorObject.message}</p>
+              <p className="italic mb-2.5 text-sm">{error.message}</p>
             </div>
             <div className="flex justify-center items-center w-full space-x-4">
               <div>
-                <Copy toCopy={errorObject.message}>
+                <Copy toCopy={error.message}>
                   <span>Copy</span>
                 </Copy>
               </div>

--- a/src/components/Tailwind/Modals/ErrorModal.tsx
+++ b/src/components/Tailwind/Modals/ErrorModal.tsx
@@ -4,14 +4,14 @@ import ModalErrorContent from '../ErrorContent/ModalErrorContent'
 
 interface ErrorModalProps {
   isVisible: boolean
-  errorObject: any // can be a blockchain tx hash or an Error
+  error: any // Error | HaloError | a blockchain tx hash
   onDismiss: () => void
 }
 
-const ErrorModal = ({ isVisible, onDismiss, errorObject }: ErrorModalProps) => {
+const ErrorModal = ({ isVisible, onDismiss, error }: ErrorModalProps) => {
   return (
     <BaseModal isVisible={isVisible} onDismiss={onDismiss}>
-      <ModalErrorContent errorObject={errorObject} onDismiss={onDismiss} />
+      <ModalErrorContent error={error} onDismiss={onDismiss} />
     </BaseModal>
   )
 }

--- a/src/halo-hooks/useErrorMessage.ts
+++ b/src/halo-hooks/useErrorMessage.ts
@@ -35,8 +35,10 @@ const useErrorMessage = () => {
       let errorMsg: string | undefined = undefined
       errorMap.forEach((value, key) => {
         if (
-          (error.message && error.message.includes(key)) || // normal error
-          ((error as any).data && (error as any).data.message.includes(key)) // tx supplied as error
+          (error.message && error.message.includes(key)) || // normal Error
+          (error instanceof HaloError &&
+            (error as HaloError).uderlyingTx &&
+            (error as HaloError).uderlyingTx.data.message.includes(key)) // HaloError with underlying tx
         ) {
           errorMsg = value
         }

--- a/src/halo-hooks/useTVLInfo.ts
+++ b/src/halo-hooks/useTVLInfo.ts
@@ -98,9 +98,13 @@ const useTVLInfo = () => {
         .catch(err => {
           console.log('Error fetching data on Studio: ', err)
           console.log('Trying to get data in Hosted')
-          getHosted().then(data => {
-            setData(data)
-          })
+          getHosted()
+            .then(data => {
+              setData(data)
+            })
+            .catch(e => {
+              console.log('Error fetching data on either Studio or Hosted: ', e)
+            })
         })
     } catch (e) {
       console.error('Error fetching data in Studio and Hosted')

--- a/src/pages/HaloHalo/HaloDepositPanel.tsx
+++ b/src/pages/HaloHalo/HaloDepositPanel.tsx
@@ -24,6 +24,7 @@ import { useTranslation } from 'react-i18next'
 import Spinner from '../../assets/images/spinner.svg'
 import { ProviderErrorCode } from 'walletlink/dist/provider/Web3Provider'
 import ErrorModal from 'components/Tailwind/Modals/ErrorModal'
+import { HaloError } from 'utils/errors/HaloError'
 
 const InputRow = styled.div<{ selected: boolean }>`
   ${({ theme }) => theme.flexRowNoWrap}
@@ -124,15 +125,15 @@ export default function CurrencyInputPanel({
     setError(undefined)
 
     try {
-      const txHash = await approve()
+      const tx = await approve()
       // user rejected tx or didn't go thru
       if (
-        txHash.code === ProviderErrorCode.USER_DENIED_REQUEST_ACCOUNTS ||
-        txHash.code === ProviderErrorCode.USER_DENIED_REQUEST_SIGNATURE
+        tx.code === ProviderErrorCode.USER_DENIED_REQUEST_ACCOUNTS ||
+        tx.code === ProviderErrorCode.USER_DENIED_REQUEST_SIGNATURE
       ) {
-        setError(txHash)
+        setError(new HaloError(t('errorMessageMetamaskRejection')))
       } else {
-        await txHash.wait()
+        await tx.wait()
       }
     } catch (e) {
       console.error(e)
@@ -140,7 +141,7 @@ export default function CurrencyInputPanel({
     } finally {
       setRequestedApproval(false)
     }
-  }, [approve, setRequestedApproval])
+  }, [t, approve, setRequestedApproval])
 
   // track and parse user input for Deposit Input
   const onUserDepositInput = useCallback((depositValue: string, max = false) => {
@@ -173,7 +174,7 @@ export default function CurrencyInputPanel({
         tx.code === ProviderErrorCode.USER_DENIED_REQUEST_ACCOUNTS ||
         tx.code === ProviderErrorCode.USER_DENIED_REQUEST_SIGNATURE
       ) {
-        setError(tx)
+        setError(new HaloError(t('errorMessageMetamaskRejection')))
       } else {
         await tx.wait()
         setDepositValue('')

--- a/src/pages/HaloHalo/HaloDepositPanel.tsx
+++ b/src/pages/HaloHalo/HaloDepositPanel.tsx
@@ -98,7 +98,7 @@ export default function CurrencyInputPanel({
   const [maxSelected, setMaxSelected] = useState(false)
   const maxDepositAmountInput = haloBalanceBigInt
   const [buttonState, setButtonState] = useState(ButtonHaloStates.Disabled)
-  const [errorObject, setErrorObject] = useState<any>(undefined)
+  const [error, setError] = useState<any>(undefined)
 
   // Updating the state of stake button
   useEffect(() => {
@@ -121,7 +121,7 @@ export default function CurrencyInputPanel({
   // handle approval
   const handleApprove = useCallback(async () => {
     setRequestedApproval(true)
-    setErrorObject(undefined)
+    setError(undefined)
 
     try {
       const txHash = await approve()
@@ -130,13 +130,13 @@ export default function CurrencyInputPanel({
         txHash.code === ProviderErrorCode.USER_DENIED_REQUEST_ACCOUNTS ||
         txHash.code === ProviderErrorCode.USER_DENIED_REQUEST_SIGNATURE
       ) {
-        setErrorObject(txHash)
+        setError(txHash)
       } else {
         await txHash.wait()
       }
     } catch (e) {
       console.error(e)
-      setErrorObject(e)
+      setError(e)
     } finally {
       setRequestedApproval(false)
     }
@@ -157,7 +157,7 @@ export default function CurrencyInputPanel({
   const deposit = async () => {
     setPendingTx(true)
     setButtonState(ButtonHaloStates.TxInProgress)
-    setErrorObject(undefined)
+    setError(undefined)
 
     let success = false
     let amount: BalanceProps | undefined
@@ -173,7 +173,7 @@ export default function CurrencyInputPanel({
         tx.code === ProviderErrorCode.USER_DENIED_REQUEST_ACCOUNTS ||
         tx.code === ProviderErrorCode.USER_DENIED_REQUEST_SIGNATURE
       ) {
-        setErrorObject(tx)
+        setError(tx)
       } else {
         await tx.wait()
         setDepositValue('')
@@ -181,7 +181,7 @@ export default function CurrencyInputPanel({
       }
     } catch (e) {
       console.error('Error catched! ', e)
-      setErrorObject(e)
+      setError(e)
     } finally {
       setPendingTx(false)
       setButtonState(ButtonHaloStates.Disabled)
@@ -316,13 +316,7 @@ export default function CurrencyInputPanel({
         </Container>
       </InputPanel>
 
-      {errorObject && (
-        <ErrorModal
-          isVisible={errorObject !== undefined}
-          onDismiss={() => setErrorObject(undefined)}
-          errorObject={errorObject}
-        />
-      )}
+      {error && <ErrorModal isVisible={error !== undefined} onDismiss={() => setError(undefined)} error={error} />}
     </>
   )
 }

--- a/src/pages/HaloHalo/HaloHaloWithdrawPanel.tsx
+++ b/src/pages/HaloHalo/HaloHaloWithdrawPanel.tsx
@@ -96,7 +96,7 @@ export default function HaloHaloWithdrawPanel({
   const maxWithdrawAmountInput = xHaloHaloBalanceBigInt
   const [buttonState, setButtonState] = useState(ButtonHaloStates.Disabled)
   const [haloToClaim, setHaloToClaim] = useState(0)
-  const [errorObject, setErrorObject] = useState<any>(undefined)
+  const [error, setError] = useState<any>(undefined)
 
   // Updating the state of stake button
   useEffect(() => {
@@ -119,7 +119,7 @@ export default function HaloHaloWithdrawPanel({
   // handle approval
   const handleApprove = useCallback(async () => {
     setRequestedApproval(true)
-    setErrorObject(undefined)
+    setError(undefined)
 
     try {
       const txHash = await approve()
@@ -130,13 +130,13 @@ export default function HaloHaloWithdrawPanel({
         txHash.code === ProviderErrorCode.USER_DENIED_REQUEST_ACCOUNTS ||
         txHash.code === ProviderErrorCode.USER_DENIED_REQUEST_SIGNATURE
       ) {
-        setErrorObject(txHash)
+        setError(txHash)
       } else {
         await txHash.wait()
       }
     } catch (e) {
       console.log(e)
-      setErrorObject(e)
+      setError(e)
     } finally {
       setRequestedApproval(false)
     }
@@ -161,7 +161,7 @@ export default function HaloHaloWithdrawPanel({
   const withdraw = async () => {
     setPendingTx(true)
     setButtonState(ButtonHaloStates.TxInProgress)
-    setErrorObject(undefined)
+    setError(undefined)
 
     let success = false
     let amount: BalanceProps | undefined
@@ -177,7 +177,7 @@ export default function HaloHaloWithdrawPanel({
         tx.code === ProviderErrorCode.USER_DENIED_REQUEST_ACCOUNTS ||
         tx.code === ProviderErrorCode.USER_DENIED_REQUEST_SIGNATURE
       ) {
-        setErrorObject(tx)
+        setError(tx)
       } else {
         await tx.wait()
         setWithdrawValue('')
@@ -185,7 +185,7 @@ export default function HaloHaloWithdrawPanel({
       }
     } catch (e) {
       console.error(e)
-      setErrorObject(e)
+      setError(e)
     } finally {
       setPendingTx(false)
       setButtonState(ButtonHaloStates.Disabled)
@@ -320,13 +320,7 @@ export default function HaloHaloWithdrawPanel({
         </Container>
       </InputPanel>
 
-      {errorObject && (
-        <ErrorModal
-          isVisible={errorObject !== undefined}
-          onDismiss={() => setErrorObject(undefined)}
-          errorObject={errorObject}
-        />
-      )}
+      {error && <ErrorModal isVisible={error !== undefined} onDismiss={() => setError(undefined)} error={error} />}
     </>
   )
 }

--- a/src/pages/HaloHalo/HaloHaloWithdrawPanel.tsx
+++ b/src/pages/HaloHalo/HaloHaloWithdrawPanel.tsx
@@ -24,6 +24,7 @@ import { ErrorText } from 'components/Alerts'
 import Column from 'components/Column'
 import { formatNumber, NumberFormat } from 'utils/formatNumber'
 import ErrorModal from 'components/Tailwind/Modals/ErrorModal'
+import { HaloError } from 'utils/errors/HaloError'
 
 const InputRow = styled.div<{ selected: boolean }>`
   ${({ theme }) => theme.flexRowNoWrap}
@@ -122,17 +123,16 @@ export default function HaloHaloWithdrawPanel({
     setError(undefined)
 
     try {
-      const txHash = await approve()
-      console.log(txHash)
+      const tx = await approve()
       // user rejected tx or didn't go thru
       if (
         // catch metamask rejection
-        txHash.code === ProviderErrorCode.USER_DENIED_REQUEST_ACCOUNTS ||
-        txHash.code === ProviderErrorCode.USER_DENIED_REQUEST_SIGNATURE
+        tx.code === ProviderErrorCode.USER_DENIED_REQUEST_ACCOUNTS ||
+        tx.code === ProviderErrorCode.USER_DENIED_REQUEST_SIGNATURE
       ) {
-        setError(txHash)
+        setError(new HaloError(t('errorMessageMetamaskRejection')))
       } else {
-        await txHash.wait()
+        await tx.wait()
       }
     } catch (e) {
       console.log(e)
@@ -177,7 +177,7 @@ export default function HaloHaloWithdrawPanel({
         tx.code === ProviderErrorCode.USER_DENIED_REQUEST_ACCOUNTS ||
         tx.code === ProviderErrorCode.USER_DENIED_REQUEST_SIGNATURE
       ) {
-        setError(tx)
+        setError(new HaloError(t('errorMessageMetamaskRejection')))
       } else {
         await tx.wait()
         setWithdrawValue('')

--- a/src/pages/Tailwind/Pool/liquidity/AddLiquidity.tsx
+++ b/src/pages/Tailwind/Pool/liquidity/AddLiquidity.tsx
@@ -21,7 +21,7 @@ const AddLiquidity = ({ pool, isEnabled }: AddLiquidityProps) => {
   const [zapAmount, setZapAmount] = useState('')
   const [isGivenBase, setIsGivenBase] = useState(true)
   const [slippage, setSlippage] = useState('3')
-  const [errorObject, setErrorObject] = useState<any>(undefined)
+  const [error, setError] = useState<any>(undefined)
 
   const { account } = useActiveWeb3React()
   const tokenBalances = useTokenBalances(account ?? undefined, [pool.token0, pool.token1])
@@ -75,15 +75,9 @@ const AddLiquidity = ({ pool, isEnabled }: AddLiquidityProps) => {
         slippage={slippage}
         isMultisided={activeSegment === 0}
         isGivenBase={isGivenBase}
-        onError={setErrorObject}
+        onError={setError}
       />
-      {errorObject && (
-        <ErrorModal
-          isVisible={errorObject !== undefined}
-          onDismiss={() => setErrorObject(undefined)}
-          errorObject={errorObject}
-        />
-      )}
+      {error && <ErrorModal isVisible={error !== undefined} onDismiss={() => setError(undefined)} error={error} />}
     </div>
   )
 }

--- a/src/pages/Tailwind/Pool/liquidity/AddLiquityModal.tsx
+++ b/src/pages/Tailwind/Pool/liquidity/AddLiquityModal.tsx
@@ -16,6 +16,7 @@ import ReactGA from 'react-ga'
 import { useTranslation } from 'react-i18next'
 import { ZapErrorCode, ZapErrorMessage, MetamaskErrorCode } from 'constants/errors'
 import InlineErrorContent from 'components/Tailwind/ErrorContent/InlineErrorContent'
+import { HaloError, HaloErrorDomain } from 'utils/errors/HaloError'
 
 enum AddLiquityModalState {
   NotConfirmed,
@@ -61,7 +62,7 @@ const AddLiquityModal = ({
   const [poolShare, setPoolShare] = useState(0)
   const [depositAmount, setDepositAmount] = useState('')
   const [isLoading, setIsLoading] = useState(false)
-  const [errorMessage, setErrorMessage] = useState<any | undefined>(undefined)
+  const [error, setError] = useState<any | undefined>(undefined)
   const { t } = useTranslation()
 
   const { calcSwapAmountForZapFromBase, calcSwapAmountForZapFromQuote, zapFromBase, zapFromQuote } = useZap(
@@ -85,7 +86,7 @@ const AddLiquityModal = ({
     if (!isMultisided && (!zapAmount || zapAmount === '')) return
 
     setIsLoading(true)
-    setErrorMessage(undefined)
+    setError(undefined)
     let baseTokenAmount = 0
     let quoteTokenAmount = 0
 
@@ -101,9 +102,9 @@ const AddLiquityModal = ({
         } catch (e) {
           console.log('error calculate', e)
           if ((e as any).code === MetamaskErrorCode.Reverted) {
-            setErrorMessage({ message: t('error-vm-exception') })
+            setError(new HaloError(t('error-vm-exception'), HaloErrorDomain.Liquidity))
           } else {
-            setErrorMessage(e as any)
+            setError(e as any)
           }
         }
       } else {
@@ -114,9 +115,9 @@ const AddLiquityModal = ({
         } catch (e) {
           console.log('error calculate', e)
           if ((e as any).code === MetamaskErrorCode.Reverted) {
-            setErrorMessage({ message: t('error-vm-exception') })
+            setError(new HaloError(t('error-vm-exception'), HaloErrorDomain.Liquidity))
           } else {
-            setErrorMessage(e as any)
+            setError(e as any)
           }
         }
       }
@@ -130,14 +131,14 @@ const AddLiquityModal = ({
         res = await previewDepositGivenBase(`${baseTokenAmount}`, pool.rates.token0, pool.weights.token0)
 
         if (Number(res.base) > Number(baseTokenAmount)) {
-          setErrorMessage({ message: t('error-liquidity-estimates-changed') })
+          setError(new HaloError(t('error-liquidity-estimates-changed'), HaloErrorDomain.Liquidity))
         }
       } catch (e) {
         console.log('error calculate', e)
         if ((e as any).code === MetamaskErrorCode.Reverted) {
-          setErrorMessage({ message: t('error-vm-exception') })
+          setError(new HaloError(t('error-vm-exception'), HaloErrorDomain.Liquidity))
         } else {
-          setErrorMessage(e as any)
+          setError(e)
         }
         onDismiss()
       }
@@ -146,14 +147,14 @@ const AddLiquityModal = ({
         res = await previewDepositGivenQuote(`${quoteTokenAmount}`)
 
         if (Number(res.quote) > Number(quoteTokenAmount)) {
-          setErrorMessage({ message: t('error-liquidity-estimates-changed') })
+          setError(new HaloError(t('error-liquidity-estimates-changed'), HaloErrorDomain.Liquidity))
         }
       } catch (e) {
         console.log('error calculate', e)
         if ((e as any).code === MetamaskErrorCode.Reverted) {
-          setErrorMessage({ message: t('error-vm-exception') })
+          setError(new HaloError(t('error-vm-exception'), HaloErrorDomain.Liquidity))
         } else {
-          setErrorMessage(e as any)
+          setError(e)
         }
         onDismiss()
       }
@@ -192,7 +193,7 @@ const AddLiquityModal = ({
       min: 0
     })
     setPoolShare(0)
-    setErrorMessage(undefined)
+    setError(undefined)
     onDismiss()
   }
 
@@ -232,7 +233,7 @@ const AddLiquityModal = ({
    **/
   const confirmZap = async () => {
     setState(AddLiquityModalState.InProgress)
-    setErrorMessage(undefined)
+    setError(undefined)
 
     try {
       const deadline = getFutureTime()
@@ -251,9 +252,9 @@ const AddLiquityModal = ({
         (err as any).code === ZapErrorCode.SlippageTooLow ||
         (err as any).message.includes(ZapErrorMessage.NotEnoughLpAmount)
       ) {
-        onError({ message: t('error-liquidity-zap-reverted') })
+        onError(new HaloError(t('error-liquidity-zap-reverted'), HaloErrorDomain.Liquidity))
       } else {
-        onError(err as any)
+        onError(err)
         onDismiss()
       }
     }
@@ -333,14 +334,14 @@ const AddLiquityModal = ({
           </div>
           <PrimaryButton
             title="Confirm Supply"
-            state={isLoading || errorMessage !== undefined ? PrimaryButtonState.Disabled : PrimaryButtonState.Enabled}
+            state={isLoading || error !== undefined ? PrimaryButtonState.Disabled : PrimaryButtonState.Enabled}
             onClick={() => {
               isMultisided ? confirmDeposit() : confirmZap()
             }}
           />
-          {errorMessage && (
+          {error && (
             <div className="mt-2">
-              <InlineErrorContent errorObject={errorMessage} />
+              <InlineErrorContent error={error} />
             </div>
           )}
         </div>

--- a/src/pages/Tailwind/Pool/liquidity/AddLiquityModal.tsx
+++ b/src/pages/Tailwind/Pool/liquidity/AddLiquityModal.tsx
@@ -16,7 +16,7 @@ import ReactGA from 'react-ga'
 import { useTranslation } from 'react-i18next'
 import { ZapErrorCode, ZapErrorMessage, MetamaskErrorCode } from 'constants/errors'
 import InlineErrorContent from 'components/Tailwind/ErrorContent/InlineErrorContent'
-import { HaloError, HaloErrorDomain } from 'utils/errors/HaloError'
+import { HaloError } from 'utils/errors/HaloError'
 
 enum AddLiquityModalState {
   NotConfirmed,
@@ -102,9 +102,9 @@ const AddLiquityModal = ({
         } catch (e) {
           console.log('error calculate', e)
           if ((e as any).code === MetamaskErrorCode.Reverted) {
-            setError(new HaloError(t('error-vm-exception'), HaloErrorDomain.Liquidity))
+            setError(new HaloError(t('error-vm-exception')))
           } else {
-            setError(e as any)
+            setError(e)
           }
         }
       } else {
@@ -115,9 +115,9 @@ const AddLiquityModal = ({
         } catch (e) {
           console.log('error calculate', e)
           if ((e as any).code === MetamaskErrorCode.Reverted) {
-            setError(new HaloError(t('error-vm-exception'), HaloErrorDomain.Liquidity))
+            setError(new HaloError(t('error-vm-exception')))
           } else {
-            setError(e as any)
+            setError(e)
           }
         }
       }
@@ -131,12 +131,12 @@ const AddLiquityModal = ({
         res = await previewDepositGivenBase(`${baseTokenAmount}`, pool.rates.token0, pool.weights.token0)
 
         if (Number(res.base) > Number(baseTokenAmount)) {
-          setError(new HaloError(t('error-liquidity-estimates-changed'), HaloErrorDomain.Liquidity))
+          setError(new HaloError(t('error-liquidity-estimates-changed')))
         }
       } catch (e) {
         console.log('error calculate', e)
         if ((e as any).code === MetamaskErrorCode.Reverted) {
-          setError(new HaloError(t('error-vm-exception'), HaloErrorDomain.Liquidity))
+          setError(new HaloError(t('error-vm-exception')))
         } else {
           setError(e)
         }
@@ -147,12 +147,12 @@ const AddLiquityModal = ({
         res = await previewDepositGivenQuote(`${quoteTokenAmount}`)
 
         if (Number(res.quote) > Number(quoteTokenAmount)) {
-          setError(new HaloError(t('error-liquidity-estimates-changed'), HaloErrorDomain.Liquidity))
+          setError(new HaloError(t('error-liquidity-estimates-changed')))
         }
       } catch (e) {
         console.log('error calculate', e)
         if ((e as any).code === MetamaskErrorCode.Reverted) {
-          setError(new HaloError(t('error-vm-exception'), HaloErrorDomain.Liquidity))
+          setError(new HaloError(t('error-vm-exception')))
         } else {
           setError(e)
         }
@@ -252,7 +252,7 @@ const AddLiquityModal = ({
         (err as any).code === ZapErrorCode.SlippageTooLow ||
         (err as any).message.includes(ZapErrorMessage.NotEnoughLpAmount)
       ) {
-        onError(new HaloError(t('error-liquidity-zap-reverted'), HaloErrorDomain.Liquidity))
+        onError(new HaloError(t('error-liquidity-zap-reverted')))
       } else {
         onError(err)
         onDismiss()

--- a/src/pages/Tailwind/Pool/liquidity/MultiSidedLiquidity.tsx
+++ b/src/pages/Tailwind/Pool/liquidity/MultiSidedLiquidity.tsx
@@ -13,7 +13,7 @@ import { MetamaskErrorCode } from 'constants/errors'
 import InlineErrorContent from 'components/Tailwind/ErrorContent/InlineErrorContent'
 import { useActiveWeb3React } from '../../../../hooks'
 import { useCurrencyBalance } from '../../../../state/wallet/hooks'
-import { HaloError, HaloErrorDomain } from 'utils/errors/HaloError'
+import { HaloError } from 'utils/errors/HaloError'
 
 enum AddLiquidityState {
   NoAmount,
@@ -82,11 +82,11 @@ const MultiSidedLiquidity = ({
 
         if (parseEther(base).gt(parseEther(val))) {
           console.error('estimate > base')
-          setError(new HaloError(t('error-liquidity-estimates-changed'), HaloErrorDomain.Liquidity))
+          setError(new HaloError(t('error-liquidity-estimates-changed')))
         }
       } catch (e) {
         if ((e as any).code === MetamaskErrorCode.Reverted) {
-          setError(new HaloError(t('error-vm-exception'), HaloErrorDomain.Liquidity))
+          setError(new HaloError(t('error-vm-exception')))
         } else {
           setError(e)
         }
@@ -113,11 +113,11 @@ const MultiSidedLiquidity = ({
 
         if (parseEther(quote).gt(parseEther(val))) {
           console.error('estimate > quote')
-          setError(new HaloError(t('error-liquidity-estimates-changed'), HaloErrorDomain.Liquidity))
+          setError(new HaloError(t('error-liquidity-estimates-changed')))
         }
       } catch (e) {
         if ((e as any).code === MetamaskErrorCode.Reverted) {
-          setError(new HaloError(t('error-vm-exception'), HaloErrorDomain.Liquidity))
+          setError(new HaloError(t('error-vm-exception')))
         } else {
           setError(e)
         }

--- a/src/pages/Tailwind/Pool/liquidity/RemoveLiquidity.tsx
+++ b/src/pages/Tailwind/Pool/liquidity/RemoveLiquidity.tsx
@@ -20,7 +20,7 @@ const RemoveLiquidity = ({ pool }: RemoveLiquidityProps) => {
   const [token1Amount, setToken1Amount] = useState(0)
   const { getFutureTime } = useTime()
   const [removeButtonState, setRemoveButtonState] = useState(PrimaryButtonState.Disabled)
-  const [errorObject, setErrorObject] = useState<any>(undefined)
+  const [error, setError] = useState<any>(undefined)
 
   const { viewWithdraw, withdraw } = useAddRemoveLiquidity(pool.address, pool.token0, pool.token1)
 
@@ -63,7 +63,7 @@ const RemoveLiquidity = ({ pool }: RemoveLiquidityProps) => {
       })
     } catch (err) {
       console.error(err)
-      setErrorObject(err)
+      setError(err)
       setRemoveButtonState(PrimaryButtonState.Enabled)
     }
   }
@@ -94,13 +94,7 @@ const RemoveLiquidity = ({ pool }: RemoveLiquidityProps) => {
       <div className="mt-4">
         <PrimaryButton title="Remove Supply" state={removeButtonState} onClick={confirmWithdraw} />
       </div>
-      {errorObject && (
-        <ErrorModal
-          isVisible={errorObject !== undefined}
-          onDismiss={() => setErrorObject(undefined)}
-          errorObject={errorObject}
-        />
-      )}
+      {error && <ErrorModal isVisible={error !== undefined} onDismiss={() => setError(undefined)} error={error} />}
     </div>
   )
 }

--- a/src/pages/Tailwind/Pool/liquidity/SingleSidedLiquidity.tsx
+++ b/src/pages/Tailwind/Pool/liquidity/SingleSidedLiquidity.tsx
@@ -15,6 +15,7 @@ import useTokenAllowance from 'halo-hooks/tokens/useTokenAllowance'
 import { MetamaskErrorCode } from 'constants/errors'
 import { useTranslation } from 'react-i18next'
 import InlineErrorContent from 'components/Tailwind/ErrorContent/InlineErrorContent'
+import { HaloError, HaloErrorDomain } from 'utils/errors/HaloError'
 
 enum AddLiquidityState {
   NoAmount,
@@ -66,12 +67,12 @@ const SingleSidedLiquidity = ({
   const [quoteZapApproveState, quoteZapApproveCallback] = useTokenAllowance(quoteTokenAmount, zapAddress)
   const baseZapApproved = baseZapApproveState === ApprovalState.APPROVED
   const quoteZapApproved = quoteZapApproveState === ApprovalState.APPROVED
-  const [errorMessage, setErrorMessage] = useState<any | undefined>(undefined)
+  const [error, setError] = useState<any | undefined>(undefined)
 
   const onBaseInputUpdate = async (val: string) => {
     setZapInput(val)
     onZapAmountChanged(val)
-    setErrorMessage(undefined)
+    setError(undefined)
     if (val === '') return
 
     let calcBaseAmount = 0
@@ -85,9 +86,9 @@ const SingleSidedLiquidity = ({
       } catch (e) {
         console.log('error calculate', e)
         if ((e as any).code === MetamaskErrorCode.Reverted) {
-          setErrorMessage({ message: t('error-vm-exception') })
+          setError(new HaloError(t('error-vm-exception'), HaloErrorDomain.Liquidity))
         } else {
-          setErrorMessage(e as any)
+          setError(e)
         }
       }
     } else {
@@ -97,7 +98,7 @@ const SingleSidedLiquidity = ({
         calcQuoteAmount = Number(val) - Number(swapAmount)
       } catch (e) {
         console.log('error calculate', e)
-        setErrorMessage(e as any)
+        setError(e)
       }
     }
 
@@ -226,7 +227,7 @@ const SingleSidedLiquidity = ({
               : 'Supply'
           }
           state={
-            errorMessage !== undefined
+            error !== undefined
               ? PrimaryButtonState.Disabled
               : mainState === AddLiquidityState.Disabled
               ? PrimaryButtonState.Disabled
@@ -238,9 +239,9 @@ const SingleSidedLiquidity = ({
           }
           onClick={() => onDeposit()}
         />
-        {errorMessage && (
+        {error && (
           <div className="mt-2">
-            <InlineErrorContent errorObject={errorMessage} />
+            <InlineErrorContent error={error} />
           </div>
         )}
       </div>

--- a/src/pages/Tailwind/Pool/liquidity/SingleSidedLiquidity.tsx
+++ b/src/pages/Tailwind/Pool/liquidity/SingleSidedLiquidity.tsx
@@ -15,7 +15,7 @@ import useTokenAllowance from 'halo-hooks/tokens/useTokenAllowance'
 import { MetamaskErrorCode } from 'constants/errors'
 import { useTranslation } from 'react-i18next'
 import InlineErrorContent from 'components/Tailwind/ErrorContent/InlineErrorContent'
-import { HaloError, HaloErrorDomain } from 'utils/errors/HaloError'
+import { HaloError } from 'utils/errors/HaloError'
 
 enum AddLiquidityState {
   NoAmount,
@@ -86,7 +86,7 @@ const SingleSidedLiquidity = ({
       } catch (e) {
         console.log('error calculate', e)
         if ((e as any).code === MetamaskErrorCode.Reverted) {
-          setError(new HaloError(t('error-vm-exception'), HaloErrorDomain.Liquidity))
+          setError(new HaloError(t('error-vm-exception')))
         } else {
           setError(e)
         }

--- a/src/pages/Tailwind/Swap/SwapPanel.tsx
+++ b/src/pages/Tailwind/Swap/SwapPanel.tsx
@@ -24,7 +24,7 @@ import { ProviderErrorCode } from 'walletlink/dist/provider/Web3Provider'
 import { ErrorDisplayType } from 'constants/errors'
 
 const SwapPanel = () => {
-  const { account, error, chainId } = useWeb3React()
+  const { account, error: web3Error, chainId } = useWeb3React()
 
   const [toCurrency, setToCurrency] = useState(
     chainId ? (haloTokenList[chainId as ChainId] as Token[])[0] : (HALO[ChainId.MAINNET] as Token)
@@ -44,7 +44,7 @@ const SwapPanel = () => {
   const [isExpired, setIsExpired] = useState(false)
   const [swapTransactionModalState, setSwapTransactionModalState] = useState(ModalState.NotConfirmed)
   const [txhash, setTxhash] = useState('')
-  const [errorObject, setErrorObject] = useState<any>(undefined)
+  const [error, setError] = useState<any>(undefined)
   const [errorDisplayType, setErrorDisplayType] = useState(ErrorDisplayType.Inline)
 
   const {
@@ -61,7 +61,7 @@ const SwapPanel = () => {
     approve,
     allowance,
     swapToken
-  } = useSwapToken(toCurrency, fromCurrency, setButtonState, setErrorObject, setErrorDisplayType)
+  } = useSwapToken(toCurrency, fromCurrency, setButtonState, setError, setErrorDisplayType)
   const handleApprove = useCallback(async () => {
     try {
       setApproveState(ApproveButtonState.Approving)
@@ -73,7 +73,7 @@ const SwapPanel = () => {
       }
     } catch (e) {
       console.log(e)
-      setErrorObject(e as any)
+      setError(e)
       setErrorDisplayType(ErrorDisplayType.Modal)
     }
   }, [approve, setApproveState])
@@ -300,7 +300,7 @@ const SwapPanel = () => {
 
   const MainContent = () => {
     const toggleWalletModal = useWalletModalToggle()
-    if (!account && !error) {
+    if (!account && !web3Error) {
       return (
         <div className="mt-2">
           <ConnectButton title="Connect to Wallet" onClick={() => toggleWalletModal()} />
@@ -342,7 +342,7 @@ const SwapPanel = () => {
                 value={fromInputValue}
                 canSelectToken={true}
                 didChangeValue={async val => {
-                  setErrorObject(undefined)
+                  setError(undefined)
                   if (parseFloat(fromAmountBalance) >= parseFloat(val)) {
                     setButtonState(SwapButtonState.Swap)
                   } else if (parseFloat(fromAmountBalance) < parseFloat(val)) {
@@ -358,7 +358,7 @@ const SwapPanel = () => {
                 balance={fromAmountBalance}
                 onSelectToken={token => {
                   if (token !== toCurrency) {
-                    setErrorObject(undefined)
+                    setError(undefined)
                     setFromCurrency(token)
                     setToInputValue('')
                     setFromInputValue('')
@@ -454,7 +454,7 @@ const SwapPanel = () => {
             ) {
               setShowModal(false)
               setSwapTransactionModalState(ModalState.NotConfirmed)
-              setErrorObject(txn)
+              setError(txn)
               setButtonState(SwapButtonState.Swap)
               setErrorDisplayType(ErrorDisplayType.Modal)
             }
@@ -462,7 +462,7 @@ const SwapPanel = () => {
             console.error('Error catched! ', e)
             setShowModal(false)
             setSwapTransactionModalState(ModalState.NotConfirmed)
-            setErrorObject(e)
+            setError(e)
             setButtonState(SwapButtonState.Swap)
           }
         }}
@@ -483,17 +483,13 @@ const SwapPanel = () => {
         txnHash={txhash}
         chainId={chainId as number}
       />
-      {errorObject && errorDisplayType === ErrorDisplayType.Inline && (
-        <div className="mt-2">
-          <InlineErrorContent errorObject={errorObject} />
+      {error && errorDisplayType === ErrorDisplayType.Inline && (
+        <div className="mt-4">
+          <InlineErrorContent error={error} />
         </div>
       )}
-      {errorObject && errorDisplayType === ErrorDisplayType.Modal && (
-        <ErrorModal
-          isVisible={errorObject !== undefined}
-          onDismiss={() => setErrorObject(undefined)}
-          errorObject={errorObject}
-        />
+      {error && errorDisplayType === ErrorDisplayType.Modal && (
+        <ErrorModal isVisible={error !== undefined} onDismiss={() => setError(undefined)} error={error} />
       )}
     </>
   )

--- a/src/tests/useErrorMessage.test.ts
+++ b/src/tests/useErrorMessage.test.ts
@@ -1,644 +1,109 @@
 import { renderHook, act } from '@testing-library/react-hooks'
-import useErrorMessage, { HaloError } from 'halo-hooks/useErrorMessage'
-
-// test('should use counter', () => {
-//     const { result } = renderHook(() => useErrorMessage())
-
-//     // expect(result.current.friendlyErrorMessage).toBeCalled()
-//     expect(typeof result.current.getFriendlyErrorMessage).toBe('function')
-//     // expect(typeof result.current.increment).toBe('function')
-// })
+import { CurveErrorMessage, GeneralErrorMessage, ZapErrorMessage } from 'constants/errors'
+import useErrorMessage from 'halo-hooks/useErrorMessage'
+import { HaloError, HaloErrorDomain } from 'utils/errors/HaloError'
 
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: any) => key })
 }))
 
-describe('Friendly Error Message Test', () => {
-  it('Should return default friendly error message when there is no match found', () => {
-    const { result } = renderHook(() => useErrorMessage())
-    const errorObject = {
-      code: 0,
-      data: '',
-      message: 'execution reverted'
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
+describe('useErrorMessage', () => {
+  describe('getFriendlyErrorMessage', () => {
+    it('Should return default friendly error message if error is unknown', () => {
+      const { result } = renderHook(() => useErrorMessage())
+      const error = new Error('VM execution error')
+      act(() => {
+        result.current.getFriendlyErrorMessage(error)
+      })
+      expect(result.current.friendlyErrorMessage).toBe('errorMessageGeneric')
     })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveDefault')
-  })
-  // Curve/re-entered
-  it('Should return the equivalent Curve re-entered friendly error', () => {
-    const { result } = renderHook(() => useErrorMessage())
-    let errorFromContract = 'execution reverted: Curve/re-entered'
-    const errorCode = -32603
-    const errorData = ''
-    let errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveReentered')
 
-    errorFromContract = 'Curve/re-entered'
-    errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveReentered')
+    it('Should return correct friendly error message for known curve errors - normal error', () => {
+      const { result } = renderHook(() => useErrorMessage())
 
-    errorFromContract = 're-entered'
-    errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveDefault')
-  })
-  /* 
-    Curve/insufficient-allowance
-    Curve/approval-overflow
-    Curve/allowance-decrease-underflow
-    */
-  it('Should return the equivalent Curve allowance friendly error', () => {
-    const { result } = renderHook(() => useErrorMessage())
-    let errorFromContract = 'execution reverted: Curve/allowance-decrease-underflow'
-    const errorCode = -32603
-    const errorData = ''
-    let errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveAllowance')
+      const errorMap = new Map()
+      errorMap.set(CurveErrorMessage.CurveReentered, 'errorMessageCurveReentered')
+      errorMap.set(CurveErrorMessage.AllowanceDecreaseUnderflow, 'errorMessageCurveAllowance')
+      errorMap.set(CurveErrorMessage.BelowMinTargetAmount, 'errorMessageCurveSwapHalt')
+      errorMap.set(CurveErrorMessage.ApprovalOverflow, 'errorMessageCurveAllowance')
+      errorMap.set(CurveErrorMessage.InsufficientAllowance, 'errorMessageCurveAllowance')
+      errorMap.set(CurveErrorMessage.Frozen, 'errorMessageCurveFrozen')
+      errorMap.set(CurveErrorMessage.EmergencyState, 'errorMessageCurveEmergency')
+      errorMap.set(CurveErrorMessage.TransactionDeadlinePassed, 'errorMessageCurveDeadlinePassed')
+      errorMap.set(CurveErrorMessage.WhitelistOnGoing, 'errorMessageCurveWhitelistingStage')
+      errorMap.set(CurveErrorMessage.WhitelistStopped, 'errorMessageCurveNotWhitelistingStage')
+      errorMap.set(CurveErrorMessage.SwapAmountTooLarge, 'errorMessageCurveAmountTooLarge')
+      errorMap.set(CurveErrorMessage.SwapConvergenceFailed, 'errorMessageCurveSwapFailed')
+      errorMap.set(CurveErrorMessage.SwapInvariantViolation, 'errorMessageCurveSwapFailed')
+      errorMap.set(CurveErrorMessage.LiquidityInvariantViolation, 'errorMessageCurveSwapFailed')
+      errorMap.set(CurveErrorMessage.UpperHalt, 'errorMessageCurveSwapHalt')
+      errorMap.set(CurveErrorMessage.LowerHalt, 'errorMessageCurveSwapHalt')
+      errorMap.set(CurveErrorMessage.CADCTransferFailed, 'errorMessageCurveERC20TransferFailed')
+      errorMap.set(GeneralErrorMessage.SubtractionOverflow, 'errorMessageSubtractionOverflow')
+      errorMap.set(GeneralErrorMessage.MetamaskRejection, 'errorMessageMetamaskRejection')
+      errorMap.set(GeneralErrorMessage.SafeMathDivisionByZero, 'errorMessageSafeMathDivisionByZero')
+      errorMap.set(ZapErrorMessage.NotEnoughLpAmount, 'error-liquidity-zap-reverted')
 
-    errorFromContract = 'Curve/allowance-decrease-underflow'
-    errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
+      errorMap.forEach((value, key) => {
+        const error = new Error(key)
+        act(() => {
+          result.current.getFriendlyErrorMessage(error)
+        })
+        expect(result.current.friendlyErrorMessage).toBe(value)
+      })
     })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveAllowance')
 
-    errorFromContract = 'execution reverted: Curve/approval-overflow'
-    errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveAllowance')
+    it('Should return correct friendly error message for known curve errors - tx as error', () => {
+      const { result } = renderHook(() => useErrorMessage())
 
-    errorFromContract = 'Curve/approval-overflow'
-    errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveAllowance')
+      const errorMap = new Map()
+      errorMap.set(CurveErrorMessage.CurveReentered, 'errorMessageCurveReentered')
+      errorMap.set(CurveErrorMessage.AllowanceDecreaseUnderflow, 'errorMessageCurveAllowance')
+      errorMap.set(CurveErrorMessage.BelowMinTargetAmount, 'errorMessageCurveSwapHalt')
+      errorMap.set(CurveErrorMessage.ApprovalOverflow, 'errorMessageCurveAllowance')
+      errorMap.set(CurveErrorMessage.InsufficientAllowance, 'errorMessageCurveAllowance')
+      errorMap.set(CurveErrorMessage.Frozen, 'errorMessageCurveFrozen')
+      errorMap.set(CurveErrorMessage.EmergencyState, 'errorMessageCurveEmergency')
+      errorMap.set(CurveErrorMessage.TransactionDeadlinePassed, 'errorMessageCurveDeadlinePassed')
+      errorMap.set(CurveErrorMessage.WhitelistOnGoing, 'errorMessageCurveWhitelistingStage')
+      errorMap.set(CurveErrorMessage.WhitelistStopped, 'errorMessageCurveNotWhitelistingStage')
+      errorMap.set(CurveErrorMessage.SwapAmountTooLarge, 'errorMessageCurveAmountTooLarge')
+      errorMap.set(CurveErrorMessage.SwapConvergenceFailed, 'errorMessageCurveSwapFailed')
+      errorMap.set(CurveErrorMessage.SwapInvariantViolation, 'errorMessageCurveSwapFailed')
+      errorMap.set(CurveErrorMessage.LiquidityInvariantViolation, 'errorMessageCurveSwapFailed')
+      errorMap.set(CurveErrorMessage.UpperHalt, 'errorMessageCurveSwapHalt')
+      errorMap.set(CurveErrorMessage.LowerHalt, 'errorMessageCurveSwapHalt')
+      errorMap.set(CurveErrorMessage.CADCTransferFailed, 'errorMessageCurveERC20TransferFailed')
+      errorMap.set(GeneralErrorMessage.SubtractionOverflow, 'errorMessageSubtractionOverflow')
+      errorMap.set(GeneralErrorMessage.MetamaskRejection, 'errorMessageMetamaskRejection')
+      errorMap.set(GeneralErrorMessage.SafeMathDivisionByZero, 'errorMessageSafeMathDivisionByZero')
+      errorMap.set(ZapErrorMessage.NotEnoughLpAmount, 'error-liquidity-zap-reverted')
 
-    errorFromContract = 'execution reverted: Curve/insufficient-allowance'
-    errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
+      errorMap.forEach((value, key) => {
+        const tx = {
+          data: {
+            message: key
+          }
+        }
+        act(() => {
+          result.current.getFriendlyErrorMessage(tx as any)
+        })
+        expect(result.current.friendlyErrorMessage).toBe(value)
+      })
     })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveAllowance')
 
-    errorFromContract = 'Curve/insufficient-allowance'
-    errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveAllowance')
-  })
-  // Curve/frozen-only-allowing-proportional-withdraw
-  it('Should return the equivalent Curve frozen friendly error', () => {
-    const { result } = renderHook(() => useErrorMessage())
-    let errorFromContract = 'execution reverted: Curve/frozen-only-allowing-proportional-withdraw'
-    const errorCode = -32603
-    const errorData = ''
-    let errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveFrozen')
+    it('Should return correct friendly error message for HaloError(s)', () => {
+      const { result } = renderHook(() => useErrorMessage())
 
-    errorFromContract = 'Curve/frozen-only-allowing-proportional-withdraw'
-    errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveFrozen')
+      const haloErrorMsgs = ['error-vm-exception', 'error-liquidity-estimates-changed', 'error-liquidity-zap-reverted']
 
-    errorFromContract = 'frozen-only-allowing-proportional-withdraw'
-    errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
+      haloErrorMsgs.map(errorMsg => {
+        const error = new HaloError(errorMsg, HaloErrorDomain.Liquidity)
+        act(() => {
+          result.current.getFriendlyErrorMessage(error)
+        })
+        expect(result.current.friendlyErrorMessage).toBe(errorMsg)
+      })
     })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveDefault')
-  })
-  // Curve/tx-deadline-passed
-  it('Should return the equivalent Curve deadline passed friendly error', () => {
-    const { result } = renderHook(() => useErrorMessage())
-    let errorFromContract = 'execution reverted: Curve/tx-deadline-passed'
-    const errorCode = -32603
-    const errorData = ''
-    let errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveDeadlinePassed')
-
-    errorFromContract = 'Curve/tx-deadline-passed'
-    errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveDeadlinePassed')
-
-    errorFromContract = 'tx-deadline-passed'
-    errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveDefault')
-  })
-  // Curve/whitelist-stage-on-going
-  it('Should return the equivalent Curve whitelist on-going friendly error', () => {
-    const { result } = renderHook(() => useErrorMessage())
-    let errorFromContract = 'execution reverted: Curve/whitelist-stage-on-going'
-    const errorCode = -32603
-    const errorData = ''
-    let errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveWhitelistingStage')
-
-    errorFromContract = 'Curve/whitelist-stage-on-going'
-    errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveWhitelistingStage')
-
-    errorFromContract = 'whitelist-stage-on-going'
-    errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveDefault')
-  })
-  // Curve/whitelist-stage-stopped
-  it('Should return the equivalent Curve whitelist stopped friendly error', () => {
-    const { result } = renderHook(() => useErrorMessage())
-    let errorFromContract = 'execution reverted: Curve/whitelist-stage-stopped'
-    const errorCode = -32603
-    const errorData = ''
-    let errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveNotWhitelistingStage')
-
-    errorFromContract = 'Curve/whitelist-stage-stopped'
-    errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveNotWhitelistingStage')
-
-    errorFromContract = 'whitelist-stage-stopped'
-    errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveDefault')
-  })
-  // Curve/amount-too-large
-  it('Should return the equivalent Curve whitelist stopped friendly error', () => {
-    const { result } = renderHook(() => useErrorMessage())
-    let errorFromContract = 'execution reverted: Curve/amount-too-large'
-    const errorCode = -32603
-    const errorData = ''
-    let errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveAmountTooLarge')
-
-    errorFromContract = 'Curve/amount-too-large'
-    errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveAmountTooLarge')
-
-    errorFromContract = 'amount-too-large'
-    errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveDefault')
-  })
-  // swap failed
-  it('Should return the equivalent Curve swap failed friendly error', () => {
-    const { result } = renderHook(() => useErrorMessage())
-    let errorFromContract = 'execution reverted: Curve/swap-convergence-failed'
-    const errorCode = -32603
-    const errorData = ''
-    let errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveSwapFailed')
-
-    errorFromContract = 'Curve/swap-convergence-failed'
-    errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveSwapFailed')
-
-    errorFromContract = 'swap-convergence-failed'
-    errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveDefault')
-
-    // Curve/swap-invariant-violation
-    errorFromContract = 'execution reverted: Curve/swap-invariant-violation'
-    errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveSwapFailed')
-
-    errorFromContract = 'Curve/swap-invariant-violation'
-    errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveSwapFailed')
-
-    errorFromContract = 'swap-invariant-violation'
-    errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveDefault')
-
-    // Curve/liquidity-invariant-violation
-    errorFromContract = 'execution reverted: Curve/liquidity-invariant-violation'
-    errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveSwapFailed')
-
-    errorFromContract = 'Curve/liquidity-invariant-violation'
-    errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveSwapFailed')
-
-    errorFromContract = 'liquidity-invariant-violation'
-    errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveDefault')
-  })
-  // Maximunm imbalance
-  it('Should return the equivalent Curve maximunm imbalance friendly error', () => {
-    const { result } = renderHook(() => useErrorMessage())
-    let errorFromContract = 'execution reverted: Curve/lower-halt'
-    const errorCode = -32603
-    const errorData = ''
-    let errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveSwapHalt')
-
-    errorFromContract = 'Curve/lower-halt'
-    errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveSwapHalt')
-
-    errorFromContract = 'lower-halt'
-    errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveDefault')
-
-    // Curve/upper-halt
-    errorFromContract = 'execution reverted: Curve/upper-halt'
-    errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveSwapHalt')
-
-    errorFromContract = 'Curve/upper-halt'
-    errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveSwapHalt')
-
-    errorFromContract = 'upper-halt'
-    errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveDefault')
-
-    // Curve/below-min-target-amount
-    errorFromContract = 'execution reverted: Curve/below-min-target-amount'
-    errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveSwapHalt')
-
-    errorFromContract = 'Curve/below-min-target-amount'
-    errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveSwapHalt')
-
-    errorFromContract = 'below-min-target-amount'
-    errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveDefault')
-  })
-  // Curve/CADC-transfer-from-failed
-  it('Should return the equivalent Curve whitelist stopped friendly error', () => {
-    const { result } = renderHook(() => useErrorMessage())
-    let errorFromContract = 'execution reverted: Curve/CADC-transfer-from-failed'
-    const errorCode = -32603
-    const errorData = ''
-    let errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveERC20TransferFailed')
-
-    errorFromContract = 'Curve/CADC-transfer-from-failed'
-    errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveERC20TransferFailed')
-
-    errorFromContract = 'CADC-transfer-from-failed'
-    errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageCurveDefault')
-  })
-  // SafeMath: subtraction overflow
-  it('Should return the equivalent SafeMath subtraction overflow friendly error', () => {
-    const { result } = renderHook(() => useErrorMessage())
-    const errorFromContract = 'SafeMath: subtraction overflow'
-    const errorCode = 0
-    const errorData = ''
-    const errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageSubtractionOverflow')
-  })
-  // SafeMath: division by zero
-  it('Should return the equivalent SafeMath division by zero friendly error', () => {
-    const { result } = renderHook(() => useErrorMessage())
-    const errorFromContract = 'SafeMath: division by zero'
-    const errorCode = 0
-    const errorData = ''
-    const errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageSafeMathDivisionByZero')
-  })
-  // User rejected tx
-  it('Should return the equivalent Metamask user rejected tx friendly error', () => {
-    const { result } = renderHook(() => useErrorMessage())
-    const errorFromContract = 'MetaMask Tx Signature: User denied transaction signature.'
-    const errorCode = 4001
-    const errorData = ''
-    const errorObject = {
-      code: errorCode,
-      data: errorData,
-      message: errorFromContract
-    }
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe('errorMessageMetamaskRejection')
-  })
-  // ErrorObject format
-  it('Should accept incomplete properties of ErrorObject and return the error message', () => {
-    const { result } = renderHook(() => useErrorMessage())
-    const errorFromContract = 'Arbitrary Error.'
-
-    const errorObject = <HaloError>{
-      message: errorFromContract
-    }
-
-    act(() => {
-      result.current.getFriendlyErrorMessage(errorObject)
-    })
-    expect(result.current.friendlyErrorMessage).toBe(errorFromContract)
   })
 })

--- a/src/tests/useErrorMessage.test.ts
+++ b/src/tests/useErrorMessage.test.ts
@@ -1,7 +1,7 @@
 import { renderHook, act } from '@testing-library/react-hooks'
 import { CurveErrorMessage, GeneralErrorMessage, ZapErrorMessage } from 'constants/errors'
 import useErrorMessage from 'halo-hooks/useErrorMessage'
-import { HaloError, HaloErrorDomain } from 'utils/errors/HaloError'
+import { HaloError } from 'utils/errors/HaloError'
 
 jest.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (key: any) => key })
@@ -9,100 +9,111 @@ jest.mock('react-i18next', () => ({
 
 describe('useErrorMessage', () => {
   describe('getFriendlyErrorMessage', () => {
-    it('Should return default friendly error message if error is unknown', () => {
-      const { result } = renderHook(() => useErrorMessage())
-      const error = new Error('VM execution error')
-      act(() => {
-        result.current.getFriendlyErrorMessage(error)
-      })
-      expect(result.current.friendlyErrorMessage).toBe('errorMessageGeneric')
-    })
-
-    it('Should return correct friendly error message for known curve errors - normal error', () => {
-      const { result } = renderHook(() => useErrorMessage())
-
-      const errorMap = new Map()
-      errorMap.set(CurveErrorMessage.CurveReentered, 'errorMessageCurveReentered')
-      errorMap.set(CurveErrorMessage.AllowanceDecreaseUnderflow, 'errorMessageCurveAllowance')
-      errorMap.set(CurveErrorMessage.BelowMinTargetAmount, 'errorMessageCurveSwapHalt')
-      errorMap.set(CurveErrorMessage.ApprovalOverflow, 'errorMessageCurveAllowance')
-      errorMap.set(CurveErrorMessage.InsufficientAllowance, 'errorMessageCurveAllowance')
-      errorMap.set(CurveErrorMessage.Frozen, 'errorMessageCurveFrozen')
-      errorMap.set(CurveErrorMessage.EmergencyState, 'errorMessageCurveEmergency')
-      errorMap.set(CurveErrorMessage.TransactionDeadlinePassed, 'errorMessageCurveDeadlinePassed')
-      errorMap.set(CurveErrorMessage.WhitelistOnGoing, 'errorMessageCurveWhitelistingStage')
-      errorMap.set(CurveErrorMessage.WhitelistStopped, 'errorMessageCurveNotWhitelistingStage')
-      errorMap.set(CurveErrorMessage.SwapAmountTooLarge, 'errorMessageCurveAmountTooLarge')
-      errorMap.set(CurveErrorMessage.SwapConvergenceFailed, 'errorMessageCurveSwapFailed')
-      errorMap.set(CurveErrorMessage.SwapInvariantViolation, 'errorMessageCurveSwapFailed')
-      errorMap.set(CurveErrorMessage.LiquidityInvariantViolation, 'errorMessageCurveSwapFailed')
-      errorMap.set(CurveErrorMessage.UpperHalt, 'errorMessageCurveSwapHalt')
-      errorMap.set(CurveErrorMessage.LowerHalt, 'errorMessageCurveSwapHalt')
-      errorMap.set(CurveErrorMessage.CADCTransferFailed, 'errorMessageCurveERC20TransferFailed')
-      errorMap.set(GeneralErrorMessage.SubtractionOverflow, 'errorMessageSubtractionOverflow')
-      errorMap.set(GeneralErrorMessage.MetamaskRejection, 'errorMessageMetamaskRejection')
-      errorMap.set(GeneralErrorMessage.SafeMathDivisionByZero, 'errorMessageSafeMathDivisionByZero')
-      errorMap.set(ZapErrorMessage.NotEnoughLpAmount, 'error-liquidity-zap-reverted')
-
-      errorMap.forEach((value, key) => {
-        const error = new Error(key)
+    describe('when supplied a normal Error', () => {
+      it('should return default friendly error message if error is unknown', () => {
+        const { result } = renderHook(() => useErrorMessage())
+        const error = new Error('VM execution error')
         act(() => {
           result.current.getFriendlyErrorMessage(error)
         })
-        expect(result.current.friendlyErrorMessage).toBe(value)
+        expect(result.current.friendlyErrorMessage).toBe('errorMessageGeneric')
+      })
+
+      it('should return correct friendly error message for known curve errors', () => {
+        const { result } = renderHook(() => useErrorMessage())
+
+        const errorMap = new Map()
+        errorMap.set(CurveErrorMessage.CurveReentered, 'errorMessageCurveReentered')
+        errorMap.set(CurveErrorMessage.AllowanceDecreaseUnderflow, 'errorMessageCurveAllowance')
+        errorMap.set(CurveErrorMessage.BelowMinTargetAmount, 'errorMessageCurveSwapHalt')
+        errorMap.set(CurveErrorMessage.ApprovalOverflow, 'errorMessageCurveAllowance')
+        errorMap.set(CurveErrorMessage.InsufficientAllowance, 'errorMessageCurveAllowance')
+        errorMap.set(CurveErrorMessage.Frozen, 'errorMessageCurveFrozen')
+        errorMap.set(CurveErrorMessage.EmergencyState, 'errorMessageCurveEmergency')
+        errorMap.set(CurveErrorMessage.TransactionDeadlinePassed, 'errorMessageCurveDeadlinePassed')
+        errorMap.set(CurveErrorMessage.WhitelistOnGoing, 'errorMessageCurveWhitelistingStage')
+        errorMap.set(CurveErrorMessage.WhitelistStopped, 'errorMessageCurveNotWhitelistingStage')
+        errorMap.set(CurveErrorMessage.SwapAmountTooLarge, 'errorMessageCurveAmountTooLarge')
+        errorMap.set(CurveErrorMessage.SwapConvergenceFailed, 'errorMessageCurveSwapFailed')
+        errorMap.set(CurveErrorMessage.SwapInvariantViolation, 'errorMessageCurveSwapFailed')
+        errorMap.set(CurveErrorMessage.LiquidityInvariantViolation, 'errorMessageCurveSwapFailed')
+        errorMap.set(CurveErrorMessage.UpperHalt, 'errorMessageCurveSwapHalt')
+        errorMap.set(CurveErrorMessage.LowerHalt, 'errorMessageCurveSwapHalt')
+        errorMap.set(CurveErrorMessage.CADCTransferFailed, 'errorMessageCurveERC20TransferFailed')
+        errorMap.set(GeneralErrorMessage.SubtractionOverflow, 'errorMessageSubtractionOverflow')
+        errorMap.set(GeneralErrorMessage.MetamaskRejection, 'errorMessageMetamaskRejection')
+        errorMap.set(GeneralErrorMessage.SafeMathDivisionByZero, 'errorMessageSafeMathDivisionByZero')
+        errorMap.set(ZapErrorMessage.NotEnoughLpAmount, 'error-liquidity-zap-reverted')
+
+        errorMap.forEach((value, key) => {
+          const error = new Error(key)
+          act(() => {
+            result.current.getFriendlyErrorMessage(error)
+          })
+          expect(result.current.friendlyErrorMessage).toBe(value)
+        })
       })
     })
 
-    it('Should return correct friendly error message for known curve errors - tx as error', () => {
-      const { result } = renderHook(() => useErrorMessage())
+    describe('when supplied a HaloError without underlyingTx', () => {
+      it('should return correct friendly error message', () => {
+        const { result } = renderHook(() => useErrorMessage())
 
-      const errorMap = new Map()
-      errorMap.set(CurveErrorMessage.CurveReentered, 'errorMessageCurveReentered')
-      errorMap.set(CurveErrorMessage.AllowanceDecreaseUnderflow, 'errorMessageCurveAllowance')
-      errorMap.set(CurveErrorMessage.BelowMinTargetAmount, 'errorMessageCurveSwapHalt')
-      errorMap.set(CurveErrorMessage.ApprovalOverflow, 'errorMessageCurveAllowance')
-      errorMap.set(CurveErrorMessage.InsufficientAllowance, 'errorMessageCurveAllowance')
-      errorMap.set(CurveErrorMessage.Frozen, 'errorMessageCurveFrozen')
-      errorMap.set(CurveErrorMessage.EmergencyState, 'errorMessageCurveEmergency')
-      errorMap.set(CurveErrorMessage.TransactionDeadlinePassed, 'errorMessageCurveDeadlinePassed')
-      errorMap.set(CurveErrorMessage.WhitelistOnGoing, 'errorMessageCurveWhitelistingStage')
-      errorMap.set(CurveErrorMessage.WhitelistStopped, 'errorMessageCurveNotWhitelistingStage')
-      errorMap.set(CurveErrorMessage.SwapAmountTooLarge, 'errorMessageCurveAmountTooLarge')
-      errorMap.set(CurveErrorMessage.SwapConvergenceFailed, 'errorMessageCurveSwapFailed')
-      errorMap.set(CurveErrorMessage.SwapInvariantViolation, 'errorMessageCurveSwapFailed')
-      errorMap.set(CurveErrorMessage.LiquidityInvariantViolation, 'errorMessageCurveSwapFailed')
-      errorMap.set(CurveErrorMessage.UpperHalt, 'errorMessageCurveSwapHalt')
-      errorMap.set(CurveErrorMessage.LowerHalt, 'errorMessageCurveSwapHalt')
-      errorMap.set(CurveErrorMessage.CADCTransferFailed, 'errorMessageCurveERC20TransferFailed')
-      errorMap.set(GeneralErrorMessage.SubtractionOverflow, 'errorMessageSubtractionOverflow')
-      errorMap.set(GeneralErrorMessage.MetamaskRejection, 'errorMessageMetamaskRejection')
-      errorMap.set(GeneralErrorMessage.SafeMathDivisionByZero, 'errorMessageSafeMathDivisionByZero')
-      errorMap.set(ZapErrorMessage.NotEnoughLpAmount, 'error-liquidity-zap-reverted')
+        const haloErrorMsgs = [
+          'error-vm-exception',
+          'error-liquidity-estimates-changed',
+          'error-liquidity-zap-reverted'
+        ]
 
-      errorMap.forEach((value, key) => {
-        const tx = {
-          data: {
-            message: key
+        haloErrorMsgs.map(errorMsg => {
+          const error = new HaloError(errorMsg)
+          act(() => {
+            result.current.getFriendlyErrorMessage(error)
+          })
+          expect(result.current.friendlyErrorMessage).toBe(errorMsg)
+        })
+      })
+    })
+
+    describe('when supplied a HaloError with underlyingTx', () => {
+      it('should return correct friendly error message for known curve errors', () => {
+        const { result } = renderHook(() => useErrorMessage())
+
+        const errorMap = new Map()
+        errorMap.set(CurveErrorMessage.CurveReentered, 'errorMessageCurveReentered')
+        errorMap.set(CurveErrorMessage.AllowanceDecreaseUnderflow, 'errorMessageCurveAllowance')
+        errorMap.set(CurveErrorMessage.BelowMinTargetAmount, 'errorMessageCurveSwapHalt')
+        errorMap.set(CurveErrorMessage.ApprovalOverflow, 'errorMessageCurveAllowance')
+        errorMap.set(CurveErrorMessage.InsufficientAllowance, 'errorMessageCurveAllowance')
+        errorMap.set(CurveErrorMessage.Frozen, 'errorMessageCurveFrozen')
+        errorMap.set(CurveErrorMessage.EmergencyState, 'errorMessageCurveEmergency')
+        errorMap.set(CurveErrorMessage.TransactionDeadlinePassed, 'errorMessageCurveDeadlinePassed')
+        errorMap.set(CurveErrorMessage.WhitelistOnGoing, 'errorMessageCurveWhitelistingStage')
+        errorMap.set(CurveErrorMessage.WhitelistStopped, 'errorMessageCurveNotWhitelistingStage')
+        errorMap.set(CurveErrorMessage.SwapAmountTooLarge, 'errorMessageCurveAmountTooLarge')
+        errorMap.set(CurveErrorMessage.SwapConvergenceFailed, 'errorMessageCurveSwapFailed')
+        errorMap.set(CurveErrorMessage.SwapInvariantViolation, 'errorMessageCurveSwapFailed')
+        errorMap.set(CurveErrorMessage.LiquidityInvariantViolation, 'errorMessageCurveSwapFailed')
+        errorMap.set(CurveErrorMessage.UpperHalt, 'errorMessageCurveSwapHalt')
+        errorMap.set(CurveErrorMessage.LowerHalt, 'errorMessageCurveSwapHalt')
+        errorMap.set(CurveErrorMessage.CADCTransferFailed, 'errorMessageCurveERC20TransferFailed')
+        errorMap.set(GeneralErrorMessage.SubtractionOverflow, 'errorMessageSubtractionOverflow')
+        errorMap.set(GeneralErrorMessage.MetamaskRejection, 'errorMessageMetamaskRejection')
+        errorMap.set(GeneralErrorMessage.SafeMathDivisionByZero, 'errorMessageSafeMathDivisionByZero')
+        errorMap.set(ZapErrorMessage.NotEnoughLpAmount, 'error-liquidity-zap-reverted')
+
+        errorMap.forEach((value, key) => {
+          const tx = {
+            data: {
+              message: key
+            }
           }
-        }
-        act(() => {
-          result.current.getFriendlyErrorMessage(tx as any)
+          const haloError = new HaloError('VM execution error', tx)
+          act(() => {
+            result.current.getFriendlyErrorMessage(haloError)
+          })
+          expect(result.current.friendlyErrorMessage).toBe(value)
         })
-        expect(result.current.friendlyErrorMessage).toBe(value)
-      })
-    })
-
-    it('Should return correct friendly error message for HaloError(s)', () => {
-      const { result } = renderHook(() => useErrorMessage())
-
-      const haloErrorMsgs = ['error-vm-exception', 'error-liquidity-estimates-changed', 'error-liquidity-zap-reverted']
-
-      haloErrorMsgs.map(errorMsg => {
-        const error = new HaloError(errorMsg, HaloErrorDomain.Liquidity)
-        act(() => {
-          result.current.getFriendlyErrorMessage(error)
-        })
-        expect(result.current.friendlyErrorMessage).toBe(errorMsg)
       })
     })
   })

--- a/src/utils/errors/HaloError.ts
+++ b/src/utils/errors/HaloError.ts
@@ -1,0 +1,18 @@
+export enum HaloErrorDomain {
+  Generic = 'Generic',
+  Swap = 'Swap',
+  Liquidity = 'AddLiquidity',
+  Rewards = 'Rewards',
+  Vesting = 'Vesting',
+  Bridge = 'Bridge'
+}
+
+export class HaloError extends Error {
+  domain: HaloErrorDomain
+
+  constructor(message: string, domain: HaloErrorDomain) {
+    super(message)
+    this.name = 'HaloError'
+    this.domain = domain
+  }
+}

--- a/src/utils/errors/HaloError.ts
+++ b/src/utils/errors/HaloError.ts
@@ -1,18 +1,9 @@
-export enum HaloErrorDomain {
-  Generic = 'Generic',
-  Swap = 'Swap',
-  Liquidity = 'AddLiquidity',
-  Rewards = 'Rewards',
-  Vesting = 'Vesting',
-  Bridge = 'Bridge'
-}
-
 export class HaloError extends Error {
-  domain: HaloErrorDomain
+  uderlyingTx: any // an optional metamask transaction which caused the error
 
-  constructor(message: string, domain: HaloErrorDomain) {
-    super(message)
+  constructor(_message: string, _uderlyingTx?: any) {
+    super(_message)
     this.name = 'HaloError'
-    this.domain = domain
+    this.uderlyingTx = _uderlyingTx
   }
 }


### PR DESCRIPTION
Refactor error messages implementation

- `getFriendlyErrorMessage()` accepts a generic "Error"
  - introduced `HaloError` class which extends `Error`, this is now what's being thrown by the components instead of an untyped object
  - still possible to pass a `tx` instead of an `Error` or `HaloError` (proven by the updated unit test)
- deprecated `HaloError` enum on InlineErrorContent & ModalErrorContent - wasn't really helpful
- default generic friendly error msg is now `errorMessageGeneric` instead of `errorMessageCurveDefault` (reason: we'll reuse the `getFriendlyErrorMessage` hook throughout the site so it won't be relevant to always say "try a different amount")
- renamed `errorObject` to `error` on the components to keep it simple and direct (`error` means an `Error` object, while `errorObject` is untyped)